### PR TITLE
Avoid web driver in instances where is not needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "yaydl"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "cienli",

--- a/src/handlers/xhamster.rs
+++ b/src/handlers/xhamster.rs
@@ -19,37 +19,27 @@
 use crate::definitions::SiteDefinition;
 
 use anyhow::{anyhow, Result};
-use fantoccini::ClientBuilder;
 use nom::Finish;
 use regex::Regex;
 use scraper::{Html, Selector};
-use tokio::runtime;
 use url::Url;
 
 use crate::VIDEO;
 
-fn get_video_info(video: &mut VIDEO, url: &str, webdriver_port: u16) -> Result<bool> {
+fn get_video_info(video: &mut VIDEO, url: &str) -> Result<bool> {
     if video.info.is_empty() {
         // We need to fetch the video information first.
         // It will contain the whole body for now.
         let local_url = url.to_owned();
 
-        let rt = runtime::Builder::new_current_thread()
-            .enable_time()
-            .enable_io()
-            .build()
-            .unwrap();
-        rt.block_on(async move {
-            let webdriver_url = format!("http://localhost:{}", webdriver_port);
-            let c = ClientBuilder::native()
-                .connect(&webdriver_url)
-                .await
-                .expect("failed to connect to web driver");
-            c.goto(&local_url).await.expect("could not go to the URL");
-            let body = c.source().await.expect("could not read the site source");
-            video.info.push_str(body.as_str());
-            c.close_window().await.expect("could not close the window");
-        });
+        video.info.push_str(
+            ureq::get(&local_url)
+                .call()
+                .expect("Could not go to the url")
+                .into_string()
+                .expect("Could not read the site source")
+                .as_str(),
+        );
     }
 
     Ok(true)
@@ -71,9 +61,9 @@ impl SiteDefinition for XHamsterHandler {
         &'a self,
         video: &'a mut VIDEO,
         url: &'a str,
-        webdriver_port: u16,
+        _webdriver_port: u16,
     ) -> Result<String> {
-        let _not_used = get_video_info(video, url, webdriver_port)?;
+        let _not_used = get_video_info(video, url)?;
         let video_info_html = Html::parse_document(video.info.as_str());
 
         let h1_selector = Selector::parse("h1").unwrap();
@@ -91,10 +81,10 @@ impl SiteDefinition for XHamsterHandler {
         &'a self,
         video: &'a mut VIDEO,
         url: &'a str,
-        webdriver_port: u16,
+        _webdriver_port: u16,
         _onlyaudio: bool,
     ) -> Result<String> {
-        let _not_used = get_video_info(video, url, webdriver_port)?;
+        let _not_used = get_video_info(video, url)?;
         let video_info_html = Html::parse_document(video.info.as_str());
 
         // Find the playlist first:
@@ -129,9 +119,9 @@ impl SiteDefinition for XHamsterHandler {
         &'a self,
         video: &'a mut VIDEO,
         url: &'a str,
-        webdriver_port: u16,
+        _webdriver_port: u16,
     ) -> Result<bool> {
-        let _video_info = get_video_info(video, url, webdriver_port);
+        let _video_info = get_video_info(video, url);
         Ok(!video.info.is_empty())
     }
 
@@ -150,7 +140,7 @@ impl SiteDefinition for XHamsterHandler {
     }
 
     fn web_driver_required<'a>(&'a self) -> bool {
-        true
+        false
     }
 }
 


### PR DESCRIPTION
Webdriver is a really useful component to simulate an user browsing the web and running javascript. However it introduces new requirements to the app, like having a compatible web browser installed. It also makes usage and configuration harder for users.

While the webdriver is useful, it really only shines when we need to evaluate Javascript. If the webpage is server statically we don't really need a webdriver. This is the case of the two sites I cover in the MR. We can replace the webdriver with a simple HTTP request and parse the html. This is way faster and way more convenient 